### PR TITLE
Fix followers page

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -4,3 +4,4 @@
 
 James Mills <prologic@shortcircuit.net.au>
 Marcos Marado <mindboosternoori@gmail.com>
+Daven Casia <davencasia@gmail.com>

--- a/templates/followers.html
+++ b/templates/followers.html
@@ -3,11 +3,11 @@
         <div>
             <hgroup>
                 <h1>Followers</h1>
-                <h2>List of users following <b>{{ .User.Username }}</b></h2>
+                <h2>List of users following <b>{{ .Profile.Username }}</b></h2>
             </hgroup>
-            {{ if .User.Followers }}
+            {{ if .Profile.Followers }}
             <ol>
-                {{ range $Nick, $URL := .User.Followers }}
+                {{ range $Nick, $URL := .Profile.Followers }}
                 <li>
                     {{ if $.User.Is $Nick }}
                     <a href="{{ $URL }}">me</a>


### PR DESCRIPTION
Fixes #52 

Problem: 
- When trying to view the followers for a feed, you'll get  a "User not found" error
- That's because we're trying to fetch it as a "user" not as a "feed"

Solution
- Get the profile of a user or a feed. I copy pasted it from the `handler#ProfileHandler`

Proof that it works
- Here's a test feed
![Screenshot from 2020-07-29 22-16-00](https://user-images.githubusercontent.com/15314237/88880305-9aa04000-d1e9-11ea-976c-7e8bbb3f42e2.png)
- Going to the followers page
![Screenshot from 2020-07-29 22-16-04](https://user-images.githubusercontent.com/15314237/88880308-9ffd8a80-d1e9-11ea-8105-6f2144677299.png)
