### PR TITLE
Use weak etags on media + avatar handler

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -167,7 +167,7 @@ func (s *Server) MediaHandler() httprouter.Handle {
 			return
 		}
 
-		etag := fmt.Sprintf("%s-%s", r.RequestURI, fileInfo.ModTime().Format(time.RFC3339))
+		etag := fmt.Sprintf("W/\"%s-%s\"", r.RequestURI, fileInfo.ModTime().Format(time.RFC3339))
 		if match := r.Header.Get("If-None-Match"); match != "" {
 			if strings.Contains(match, etag) {
 				w.WriteHeader(http.StatusNotModified)
@@ -209,7 +209,7 @@ func (s *Server) AvatarHandler() httprouter.Handle {
 
 		fn := filepath.Join(s.config.Data, avatarsDir, fmt.Sprintf("%s.png", nick))
 		if fileInfo, err := os.Stat(fn); err == nil {
-			etag := fmt.Sprintf("%s-%s", r.RequestURI, fileInfo.ModTime().Format(time.RFC3339))
+			etag := fmt.Sprintf("W/\"%s-%s\"", r.RequestURI, fileInfo.ModTime().Format(time.RFC3339))
 
 			if match := r.Header.Get("If-None-Match"); match != "" {
 				if strings.Contains(match, etag) {


### PR DESCRIPTION
Etags needs to get wrapped with quotes. See [docs](https://support.cloudflare.com/hc/en-us/articles/218505467-Using-ETag-Headers-with-Cloudflare)
> set a strong ETag header in quotes (Etag: "example") or Cloudflare removes the ETag instead of converting it to a weak ETag. 

Also I used weak etags instead of strong etags because strong etags is only available for enterprise plan. 

Proof that it sets the proper header:
![Screenshot from 2020-08-01 22-01-01](https://user-images.githubusercontent.com/15314237/89115211-e6015b00-d442-11ea-8af2-770ceff7645a.png)

It may fix #64 
