### PR TITLE
Add feature to allow users to manage their subFeeds

### DIFF
--- a/internal/handlers.go
+++ b/internal/handlers.go
@@ -151,7 +151,7 @@ func (s *Server) ManageFeedHandler() httprouter.Handle {
 		if err != nil {
 			log.WithError(err).Errorf("error loading feed object for %s", feedName)
 			ctx.Error = true
-			if errors.Is(err, ErrFeedNotFound) {
+			if err == ErrFeedNotFound {
 				ctx.Message = "Feed not found"
 				s.render("404", w, ctx)
 			}
@@ -214,7 +214,7 @@ func (s *Server) ArchiveFeedHandler() httprouter.Handle {
 		if err != nil {
 			log.WithError(err).Errorf("error loading feed object for %s", feedName)
 			ctx.Error = true
-			if errors.Is(err, ErrFeedNotFound) {
+			if err == ErrFeedNotFound {
 				ctx.Message = "Feed not found"
 				s.render("404", w, ctx)
 			}

--- a/internal/handlers.go
+++ b/internal/handlers.go
@@ -138,18 +138,18 @@ func (s *Server) ProfileHandler() httprouter.Handle {
 func (s *Server) ManageFeedHandler() httprouter.Handle {
 	return func(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
 		ctx := NewContext(s.config, s.db, r)
-		nick := NormalizeUsername(p.ByName("nick"))
+		feedName := NormalizeFeedName(p.ByName("name"))
 
-		if nick == "" {
+		if feedName == "" {
 			ctx.Error = true
 			ctx.Message = "No feed specified"
 			s.render("error", w, ctx)
 			return
 		}
 
-		feed, err := s.db.GetFeed(nick)
+		feed, err := s.db.GetFeed(feedName)
 		if err != nil {
-			log.WithError(err).Errorf("error loading feed object for %s", nick)
+			log.WithError(err).Errorf("error loading feed object for %s", feedName)
 			ctx.Error = true
 			if errors.Is(err, ErrFeedNotFound) {
 				ctx.Message = "Feed not found"
@@ -197,22 +197,22 @@ func (s *Server) ManageFeedHandler() httprouter.Handle {
 	}
 }
 
-// DeleteFeedHandler...
-func (s *Server) DeleteFeedHandler() httprouter.Handle {
+// ArchiveFeedHandler...
+func (s *Server) ArchiveFeedHandler() httprouter.Handle {
 	return func(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
 		ctx := NewContext(s.config, s.db, r)
-		nick := NormalizeUsername(p.ByName("nick"))
+		feedName := NormalizeFeedName(p.ByName("name"))
 
-		if nick == "" {
+		if feedName == "" {
 			ctx.Error = true
 			ctx.Message = "No feed specified"
 			s.render("error", w, ctx)
 			return
 		}
 
-		feed, err := s.db.GetFeed(nick)
+		feed, err := s.db.GetFeed(feedName)
 		if err != nil {
-			log.WithError(err).Errorf("error loading feed object for %s", nick)
+			log.WithError(err).Errorf("error loading feed object for %s", feedName)
 			ctx.Error = true
 			if errors.Is(err, ErrFeedNotFound) {
 				ctx.Message = "Feed not found"
@@ -233,13 +233,13 @@ func (s *Server) DeleteFeedHandler() httprouter.Handle {
 		if err := DetachFeedFromOwner(s.db, ctx.User, feed); err != nil {
 			log.WithError(err).Warnf("Error detaching feed owner %s from feed %s", ctx.User.Username, feed.Name)
 			ctx.Error = true
-			ctx.Message = "Error deleting feed"
+			ctx.Message = "Error archiving feed"
 			s.render("error", w, ctx)
 			return
 		}
 
 		ctx.Error = false
-		ctx.Message = "Successfully deleted feed"
+		ctx.Message = "Successfully archived feed"
 		s.render("error", w, ctx)
 	}
 }

--- a/internal/models.go
+++ b/internal/models.go
@@ -102,6 +102,20 @@ func CreateFeed(conf *Config, db Store, user *User, name string, force bool) err
 	return nil
 }
 
+func DetachFeedFromOwner(db Store, user *User, feed *Feed) (err error ) {
+	user.Feeds = RemoveString(user.Feeds, feed.Name)
+	if err = db.SetUser(user.Username, user); err != nil {
+		return
+	}
+
+	delete(feed.Followers, user.Username)
+	if err = db.SetFeed(feed.Name, feed); err != nil {
+		return
+	}
+
+	return nil
+}
+
 func LoadFeed(data []byte) (feed *Feed, err error) {
 	if err = json.Unmarshal(data, &feed); err != nil {
 		return nil, err

--- a/internal/server.go
+++ b/internal/server.go
@@ -215,8 +215,9 @@ func (s *Server) initRoutes() {
 	s.router.HEAD("/user/:nick/twtxt.txt", s.TwtxtHandler())
 	s.router.GET("/user/:nick/twtxt.txt", s.TwtxtHandler())
 	s.router.GET("/user/:nick/followers", s.FollowersHandler())
-	s.router.GET("/user/:nick/manage-feed", s.am.MustAuth(s.ManageProfileHandler()))
-	s.router.POST("/user/:nick/manage-feed", s.am.MustAuth(s.ManageProfileHandler()))
+	s.router.GET("/user/:nick/manage-feed", s.am.MustAuth(s.ManageFeedHandler()))
+	s.router.POST("/user/:nick/manage-feed", s.am.MustAuth(s.ManageFeedHandler()))
+	s.router.POST("/user/:nick/delete-feed", s.am.MustAuth(s.DeleteFeedHandler()))
 
 	s.router.GET("/login", s.LoginHandler())
 	s.router.POST("/login", s.LoginHandler())

--- a/internal/server.go
+++ b/internal/server.go
@@ -215,9 +215,10 @@ func (s *Server) initRoutes() {
 	s.router.HEAD("/user/:nick/twtxt.txt", s.TwtxtHandler())
 	s.router.GET("/user/:nick/twtxt.txt", s.TwtxtHandler())
 	s.router.GET("/user/:nick/followers", s.FollowersHandler())
-	s.router.GET("/user/:nick/manage-feed", s.am.MustAuth(s.ManageFeedHandler()))
-	s.router.POST("/user/:nick/manage-feed", s.am.MustAuth(s.ManageFeedHandler()))
-	s.router.POST("/user/:nick/delete-feed", s.am.MustAuth(s.DeleteFeedHandler()))
+
+	s.router.GET("/feed/:name/manage", s.am.MustAuth(s.ManageFeedHandler()))
+	s.router.POST("/feed/:name/manage", s.am.MustAuth(s.ManageFeedHandler()))
+	s.router.POST("/feed/:name/archive", s.am.MustAuth(s.ArchiveFeedHandler()))
 
 	s.router.GET("/login", s.LoginHandler())
 	s.router.POST("/login", s.LoginHandler())

--- a/internal/server.go
+++ b/internal/server.go
@@ -215,6 +215,8 @@ func (s *Server) initRoutes() {
 	s.router.HEAD("/user/:nick/twtxt.txt", s.TwtxtHandler())
 	s.router.GET("/user/:nick/twtxt.txt", s.TwtxtHandler())
 	s.router.GET("/user/:nick/followers", s.FollowersHandler())
+	s.router.GET("/user/:nick/manage-feed", s.am.MustAuth(s.ManageProfileHandler()))
+	s.router.POST("/user/:nick/manage-feed", s.am.MustAuth(s.ManageProfileHandler()))
 
 	s.router.GET("/login", s.LoginHandler())
 	s.router.POST("/login", s.LoginHandler())

--- a/internal/templates/feeds.html
+++ b/internal/templates/feeds.html
@@ -39,6 +39,10 @@
             {{ else }}
               [<a href="/follow?nick={{ .Name  }}&url={{ .URL }}">Follow</a>]
             {{ end }}
+
+            {{ if $.User.OwnsFeed .Name }}
+              [<a href="/user/{{ .Name  }}/manage-feed">Manage</a>]
+            {{ end }}
           </li>
         {{ end }}
       </ul>

--- a/internal/templates/feeds.html
+++ b/internal/templates/feeds.html
@@ -41,7 +41,7 @@
             {{ end }}
 
             {{ if $.User.OwnsFeed .Name }}
-              [<a href="/user/{{ .Name  }}/manage-feed">Manage</a>]
+              [<a href="/feed/{{ .Name  }}/manage">Manage</a>]
             {{ end }}
           </li>
         {{ end }}

--- a/internal/templates/manageFeed.html
+++ b/internal/templates/manageFeed.html
@@ -5,7 +5,7 @@
             <h1>Manage feed</h1>
             <h2>Manage <b>{{ .Profile.Username}}</b> details</h2>
         </hgroup>
-        <form action="/user/{{  .Profile.Username }}/manage-feed" method="POST">
+        <form action="/feed/{{  .Profile.Username }}/manage" method="POST">
             <label for="description">
                 Description
                 <input type="text" id="description" name="description" placeholder="A short description about the feed" required value="{{ .Profile.Tagline }}">
@@ -14,15 +14,15 @@
         </form>
 
         <hgroup>
-            <h1>Delete feed</h1>
-            <h2>Here you may delete your custom feed</h2>
+            <h1>Archive feed</h1>
+            <h2>Here you may archive your custom feed</h2>
         </hgroup>
         <p>
             <b>WARNING:</b>&nbsp;This is permanent and cannot be undone!
             (<i>There is no confirmation!</i>)
         </p>
-        <form action="/user/{{  .Profile.Username }}/delete-feed" method="POST" onsubmit="return confirm('Are you sure you want to delete this feed? This cannot be undone!');">
-            <button type="submit" class="contrast">Delete</button>
+        <form action="/feed/{{  .Profile.Username }}/archive" method="POST" onsubmit="return confirm('Are you sure you want to archive this feed? This cannot be undone!');">
+            <button type="submit" class="contrast">Archive</button>
         </form>
     </div>
 </article>

--- a/internal/templates/profile.html
+++ b/internal/templates/profile.html
@@ -25,7 +25,7 @@
             {{ end }}
 
             {{ if $.User.OwnsFeed .Profile.Username }}
-              | <a href="/user/{{ .Profile.Username  }}/manage-feed">Manage</a>
+              | <a href="/feed/{{ .Profile.Username  }}/manage">Manage</a>
             {{ end }}
           </h3>
         {{ end}}

--- a/internal/templates/profile.html
+++ b/internal/templates/profile.html
@@ -23,6 +23,10 @@
                 Follow
               </a>
             {{ end }}
+
+            {{ if $.User.OwnsFeed .Profile.Username }}
+              | <a href="/user/{{ .Profile.Username  }}/manage-feed">Manage</a>
+            {{ end }}
           </h3>
         {{ end}}
         <footer>

--- a/templates/manageFeed.html
+++ b/templates/manageFeed.html
@@ -3,7 +3,7 @@
     <div>
         <hgroup>
             <h1>Manage feed</h1>
-            <h2>Manage {{ .Profile.Username}} feed details</h2>
+            <h2>Manage <b>{{ .Profile.Username}}</b> details</h2>
         </hgroup>
         <form action="/user/{{  .Profile.Username }}/manage-feed" method="POST">
             <label for="description">

--- a/templates/manageFeed.html
+++ b/templates/manageFeed.html
@@ -3,14 +3,26 @@
     <div>
         <hgroup>
             <h1>Manage feed</h1>
-            <h2>Manage {{ .Profile.Username}}</h2>
+            <h2>Manage {{ .Profile.Username}} feed details</h2>
         </hgroup>
         <form action="/user/{{  .Profile.Username }}/manage-feed" method="POST">
             <label for="description">
                 Description
-                <input type="text" id="description" name="description" placeholder="Description" required value="{{ .Profile.Tagline }}">
+                <input type="text" id="description" name="description" placeholder="A short description about the feed" required value="{{ .Profile.Tagline }}">
             </label>
-            <button type="submit" class="contrast">Update</button>
+            <button type="submit">Update</button>
+        </form>
+
+        <hgroup>
+            <h1>Delete feed</h1>
+            <h2>Here you may delete your custom feed</h2>
+        </hgroup>
+        <p>
+            <b>WARNING:</b>&nbsp;This is permanent and cannot be undone!
+            (<i>There is no confirmation!</i>)
+        </p>
+        <form action="/user/{{  .Profile.Username }}/delete-feed" method="POST" onsubmit="return confirm('Are you sure you want to delete this feed? This cannot be undone!');">
+            <button type="submit" class="contrast">Delete</button>
         </form>
     </div>
 </article>

--- a/templates/manageFeed.html
+++ b/templates/manageFeed.html
@@ -1,0 +1,17 @@
+{{define "content"}}
+<article class="grid">
+    <div>
+        <hgroup>
+            <h1>Manage feed</h1>
+            <h2>Manage {{ .Profile.Username}}</h2>
+        </hgroup>
+        <form action="/user/{{  .Profile.Username }}/manage-feed" method="POST">
+            <label for="description">
+                Description
+                <input type="text" id="description" name="description" placeholder="Description" required value="{{ .Profile.Tagline }}">
+            </label>
+            <button type="submit" class="contrast">Update</button>
+        </form>
+    </div>
+</article>
+{{ end }}


### PR DESCRIPTION
Changes
- Added /user/<feed_name>/manage-feed endpoint for managing feed. 
- User can update description and delete a feed
- Added a link to manage feed from the feed's profile

Update description
![description_update](https://user-images.githubusercontent.com/15314237/89144357-bcac0200-d50a-11ea-9771-60f646239442.gif)

Deleting a feed
![delete_feed](https://user-images.githubusercontent.com/15314237/89144407-efee9100-d50a-11ea-924e-2a82871ab27c.gif)

Link to `Manage` feed from feed's profile
![Screenshot from 2020-08-02 21-51-53](https://user-images.githubusercontent.com/15314237/89144412-f54bdb80-d50a-11ea-8e03-eee13758dcfa.png)

NOTE: Im not really sure about the "Delete feed" wording because it's not deleting it. Lmk if you have suggestion on what should it be. 
