### PR TITLE
Remove the following & sources when archiving a feed

### DIFF
--- a/internal/models.go
+++ b/internal/models.go
@@ -102,7 +102,10 @@ func CreateFeed(conf *Config, db Store, user *User, name string, force bool) err
 	return nil
 }
 
-func DetachFeedFromOwner(db Store, user *User, feed *Feed) (err error ) {
+func DetachFeedFromOwner(db Store, user *User, feed *Feed) (err error) {
+	delete(user.Following, feed.Name)
+	delete(user.sources, feed.URL)
+
 	user.Feeds = RemoveString(user.Feeds, feed.Name)
 	if err = db.SetUser(user.Username, user); err != nil {
 		return


### PR DESCRIPTION
## Problem
- The `Unfollow` button still shows when you archive your custom feed

## Solution
- When deleting a feed, stop following that feed & remove the feed from your sources

Here i created a feed called `My own feed`
![Screenshot from 2020-08-03 17-17-35](https://user-images.githubusercontent.com/15314237/89236367-98edc800-d5ad-11ea-816b-10b8e6416909.png)

After archiving it, the [Follow] button is now removed
![Screenshot from 2020-08-03 17-17-35](https://user-images.githubusercontent.com/15314237/89236387-a5722080-d5ad-11ea-8543-519d3de5754f.png)

In the profile page, you can see that im not following that feed anymore
![Screenshot from 2020-08-03 17-17-40](https://user-images.githubusercontent.com/15314237/89236419-bb7fe100-d5ad-11ea-8c66-b963a61c62f9.png)
