### PR TITLE
Add hashtag search

### DIFF
--- a/internal/cache.go
+++ b/internal/cache.go
@@ -17,7 +17,7 @@ import (
 )
 
 type Cached struct {
-	Twts       Twts
+	Twts         Twts
 	Lastmodified string
 }
 

--- a/internal/handlers.go
+++ b/internal/handlers.go
@@ -763,6 +763,13 @@ func (s *Server) SearchHandler() httprouter.Handle {
 
 		cache, err := LoadCache(s.config.Data)
 
+		if err != nil {
+			ctx.Error = true
+			ctx.Message = "An error occurred while loading search results"
+			s.render("error", w, ctx)
+			return
+		}
+
 		tag := r.URL.Query().Get("tag")
 
 		if tag == "" {
@@ -779,13 +786,6 @@ func (s *Server) SearchHandler() httprouter.Handle {
 				}
 			}
 			return result
-		}
-
-		if err != nil {
-			ctx.Error = true
-			ctx.Message = "An error occurred while loading search results"
-			s.render("error", w, ctx)
-			return
 		}
 
 		twts = getTweetsByTag()

--- a/internal/handlers.go
+++ b/internal/handlers.go
@@ -767,11 +767,11 @@ func (s *Server) SearchHandler() httprouter.Handle {
 
 		if tag == "" {
 			ctx.Error = true
-			ctx.Message = "At least 1 search tag is required"
+			ctx.Message = "At least search query is required"
 			s.render("error", w, ctx)
 		}
 
-		getTweetByTag := func() Twts {
+		getTweetsByTag := func() Twts {
 			var result Twts
 			for _, twt := range cache.GetAll() {
 				if HasString(UniqStrings(twt.Tags()), tag) {
@@ -783,12 +783,12 @@ func (s *Server) SearchHandler() httprouter.Handle {
 
 		if err != nil {
 			ctx.Error = true
-			ctx.Message = "An error occurred while loading mentions"
+			ctx.Message = "An error occurred while loading search results"
 			s.render("error", w, ctx)
 			return
 		}
 
-		twts = getTweetByTag()
+		twts = getTweetsByTag()
 
 		sort.Sort(sort.Reverse(twts))
 
@@ -800,7 +800,7 @@ func (s *Server) SearchHandler() httprouter.Handle {
 
 		if err = pager.Results(&pagedTwts); err != nil {
 			ctx.Error = true
-			ctx.Message = "An error occurred while loading mentions"
+			ctx.Message = "An error occurred while loading search results"
 			s.render("error", w, ctx)
 			return
 		}

--- a/internal/handlers.go
+++ b/internal/handlers.go
@@ -754,6 +754,64 @@ func (s *Server) MentionsHandler() httprouter.Handle {
 	}
 }
 
+// SearchHandler ...
+func (s *Server) SearchHandler() httprouter.Handle {
+	return func(w http.ResponseWriter, r *http.Request, p httprouter.Params) {
+		ctx := NewContext(s.config, s.db, r)
+
+		var twts Twts
+
+		cache, err := LoadCache(s.config.Data)
+
+		tag := r.URL.Query().Get("tag")
+
+		if tag == "" {
+			ctx.Error = true
+			ctx.Message = "At least 1 search tag is required"
+			s.render("error", w, ctx)
+		}
+
+		getTweetByTag := func() Twts {
+			var result Twts
+			for _, twt := range cache.GetAll() {
+				if HasString(UniqStrings(twt.Tags()), tag) {
+					result = append(result, twt)
+				}
+			}
+			return result
+		}
+
+		if err != nil {
+			ctx.Error = true
+			ctx.Message = "An error occurred while loading mentions"
+			s.render("error", w, ctx)
+			return
+		}
+
+		twts = getTweetByTag()
+
+		sort.Sort(sort.Reverse(twts))
+
+		var pagedTwts Twts
+
+		page := SafeParseInt(r.FormValue("page"), 1)
+		pager := paginator.New(adapter.NewSliceAdapter(twts), s.config.TwtsPerPage)
+		pager.SetPage(page)
+
+		if err = pager.Results(&pagedTwts); err != nil {
+			ctx.Error = true
+			ctx.Message = "An error occurred while loading mentions"
+			s.render("error", w, ctx)
+			return
+		}
+
+		ctx.Twts = pagedTwts
+		ctx.Pager = pager
+
+		s.render("timeline", w, ctx)
+	}
+}
+
 // FeedHandler ...
 func (s *Server) FeedHandler() httprouter.Handle {
 	return func(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {

--- a/internal/server.go
+++ b/internal/server.go
@@ -200,6 +200,7 @@ func (s *Server) initRoutes() {
 
 	s.router.GET("/discover", s.am.MustAuth(s.DiscoverHandler()))
 	s.router.GET("/mentions", s.am.MustAuth(s.MentionsHandler()))
+	s.router.GET("/search", s.SearchHandler())
 
 	s.router.GET("/feeds", s.am.MustAuth(s.FeedsHandler()))
 	s.router.POST("/feed", s.am.MustAuth(s.FeedHandler()))

--- a/internal/twt.go
+++ b/internal/twt.go
@@ -52,6 +52,18 @@ func (twt Twt) Mentions() []string {
 	return mentions
 }
 
+func (twt Twt) Tags() []string {
+	var mentions []string
+
+	re := regexp.MustCompile(`#<(.*?) .*?>`)
+	matches := re.FindAllStringSubmatch(twt.Text, -1)
+	for _, match := range matches {
+		mentions = append(mentions, match[1])
+	}
+
+	return mentions
+}
+
 func (twt Twt) Subject() string {
 	re := regexp.MustCompile(`^(@<.*>[, ]*)*(\(.*?\))(.*)`)
 	match := re.FindStringSubmatch(twt.Text)

--- a/internal/twt.go
+++ b/internal/twt.go
@@ -135,7 +135,7 @@ func ExpandMentions(conf *Config, db Store, user *User, text string) string {
 	})
 }
 
-// Turns "@nick" into "@<nick URL>" if we're following nick.
+// Turns #tag into "@<tag URL>"
 func ExpandTag(conf *Config, db Store, user *User, text string) string {
 	re := regexp.MustCompile(`#([-\w]+)`)
 	return re.ReplaceAllStringFunc(text, func(match string) string {
@@ -195,9 +195,10 @@ func AppendTwt(conf *Config, db Store, user *User, text string) error {
 	}
 	defer f.Close()
 
-	text = fmt.Sprintf("%s\t%s\n", time.Now().Format(time.RFC3339), ExpandTag(conf, db, user, ExpandMentions(conf, db, user, text)))
-
-	if _, err = f.WriteString(text); err != nil {
+	if _, err = f.WriteString(
+		fmt.Sprintf("%s\t%s\n", time.Now().Format(time.RFC3339),
+			ExpandTag(conf, db, user, ExpandMentions(conf, db, user, text))),
+	); err != nil {
 		return err
 	}
 

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -365,6 +365,14 @@ func URLForUser(baseURL, username string) string {
 	)
 }
 
+func URLForTag(baseURL, tag string) string {
+	return fmt.Sprintf(
+		"%s/search?tag=%s",
+		strings.TrimSuffix(baseURL, "/"),
+		tag,
+	)
+}
+
 // SafeParseInt ...
 func SafeParseInt(s string, d int) int {
 	n, e := strconv.Atoi(s)
@@ -468,11 +476,11 @@ func FormatTwtFactory(conf *Config) func(text string) template.HTML {
 
 // FormatMentions turns `@<nick URL>` into `<a href="URL">@nick</a>`
 func FormatMentions(text string) string {
-	re := regexp.MustCompile(`@<([^ ]+) *([^>]+)>`)
+	re := regexp.MustCompile(`(@|#)<([^ ]+) *([^>]+)>`)
 	return re.ReplaceAllStringFunc(text, func(match string) string {
 		parts := re.FindStringSubmatch(match)
-		nick, url := parts[1], parts[2]
-		return fmt.Sprintf(`<a href="%s">@%s</a>`, url, nick)
+		prefix, nick, url := parts[1], parts[2], parts[3]
+		return fmt.Sprintf(`<a href="%s">%s%s</a>`, url, prefix, nick)
 	})
 }
 

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -464,7 +464,7 @@ func FormatTwtFactory(conf *Config) func(text string) template.HTML {
 		}
 		renderer := html.NewRenderer(opts)
 
-		md := []byte(FormatMentions(text))
+		md := []byte(FormatMentionsAndTags(text))
 		maybeUnsafeHTML := markdown.ToHTML(md, nil, renderer)
 		p := bluemonday.UGCPolicy()
 		p.AllowAttrs("target").OnElements("a")
@@ -474,8 +474,9 @@ func FormatTwtFactory(conf *Config) func(text string) template.HTML {
 	}
 }
 
-// FormatMentions turns `@<nick URL>` into `<a href="URL">@nick</a>`
-func FormatMentions(text string) string {
+// FormatMentionsAndTags turns `@<nick URL>` into `<a href="URL">@nick</a>`
+//     and `#<tag URL>` into `<a href="URL">#tag</a>`
+func FormatMentionsAndTags(text string) string {
 	re := regexp.MustCompile(`(@|#)<([^ ]+) *([^>]+)>`)
 	return re.ReplaceAllStringFunc(text, func(match string) string {
 		parts := re.FindStringSubmatch(match)


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue or `Closes #nnn`
if you are implementing a new feature or enhancing an existing one.

In "Component Name" section write which component is changed in this PR. This
will help us review your PR quicker.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
Fixes #78 
-  Added `/search` endpoint that takes a `tag=<your_tag>` search query param
- Twts with `#hashtags` now gets expanded to `<a href="<pod_url>/search?tag=hashtag>hashtag</a>`

##### Component Name
- Formatting of twts

##### Test Plan
1. Add a tweet with a hashtag e.g. `#waddup`
2. Go to the timeline page. Check to see if the tag got transformed to a link
3. Click on that link. Verify that it takes you to the search page
![out](https://user-images.githubusercontent.com/15314237/89720548-67e80b80-d990-11ea-8238-4e8904710cb3.gif)


##### Additional Information
N/A
