### PR TITLE
Display the proper hashtag for replies

### DIFF
--- a/internal/models.go
+++ b/internal/models.go
@@ -276,6 +276,7 @@ func (u *User) Reply(twt types.Twt) string {
 	subject := twt.Subject()
 
 	if subject != "" {
+		subject = FormatMentionsAndTagsForSubject(subject)
 		return fmt.Sprintf("%s %s ", strings.Join(mentions, " "), subject)
 	}
 	return fmt.Sprintf("%s ", strings.Join(mentions, " "))

--- a/internal/utils.go
+++ b/internal/utils.go
@@ -485,6 +485,16 @@ func FormatMentionsAndTags(text string) string {
 	})
 }
 
+// FormatMentionsAndTagsForSubject turns `@<nick URL>` into `@nick`
+func FormatMentionsAndTagsForSubject(text string) string {
+	re := regexp.MustCompile(`(@|#)<([^ ]+) *([^>]+)>`)
+	return re.ReplaceAllStringFunc(text, func(match string) string {
+		parts := re.FindStringSubmatch(match)
+		prefix, nick := parts[1], parts[2]
+		return fmt.Sprintf(`%s%s`, prefix, nick)
+	})
+}
+
 // FormatRequest generates ascii representation of a request
 func FormatRequest(r *http.Request) string {
 	return fmt.Sprintf(

--- a/types/twt.go
+++ b/types/twt.go
@@ -39,15 +39,15 @@ func (twt Twt) Mentions() []string {
 
 // Tags ...
 func (twt Twt) Tags() []string {
-	var mentions []string
+	var tags []string
 
 	re := regexp.MustCompile(`#<(.*?) .*?>`)
 	matches := re.FindAllStringSubmatch(twt.Text, -1)
 	for _, match := range matches {
-		mentions = append(mentions, match[1])
+		tags = append(tags, match[1])
 	}
 
-	return mentions
+	return tags
 }
 
 // Subject ...


### PR DESCRIPTION
### Summary
When replying to a tweet that has a subject that contains a hashtag/mention, it displays a html representation of a link 

We want to keep the hashtag/mention as it is when replying
Related to #78 
##### Component Name
area/backend
##### Test Plan
1. Find a tweet that has a subject that contains hashtag/mention 
2. Click reply
![out](https://user-images.githubusercontent.com/15314237/89736911-4b001680-da2a-11ea-8aa6-c7d13f3204df.gif)


##### Additional Information
