### PR TITLE
Add etags for default avatar

### DIFF
--- a/internal/handlers.go
+++ b/internal/handlers.go
@@ -396,9 +396,20 @@ func (s *Server) AvatarHandler() httprouter.Handle {
 			return
 		}
 
+		etag := fmt.Sprintf("W/\"%s-%s\"", r.RequestURI, time.Date(0, 0, 0, 0, 0, 0, 0, time.UTC))
+
+		if match := r.Header.Get("If-None-Match"); match != "" {
+			if strings.Contains(match, etag) {
+				w.WriteHeader(http.StatusNotModified)
+				return
+			}
+		}
+
 		buf := bytes.Buffer{}
 		img := cameron.Identicon([]byte(nick), 60, 12)
 		png.Encode(&buf, img)
+
+		w.Header().Set("Etag", etag)
 		w.Write(buf.Bytes())
 	}
 }

--- a/internal/handlers.go
+++ b/internal/handlers.go
@@ -396,7 +396,7 @@ func (s *Server) AvatarHandler() httprouter.Handle {
 			return
 		}
 
-		etag := fmt.Sprintf("W/\"%s-%s\"", r.RequestURI, time.Date(0, 0, 0, 0, 0, 0, 0, time.UTC))
+		etag := fmt.Sprintf("W/\"%s\"", r.RequestURI)
 
 		if match := r.Header.Get("If-None-Match"); match != "" {
 			if strings.Contains(match, etag) {


### PR DESCRIPTION
##### Summary
We want to add etags for the default avatar

##### Component Name
area/backend

##### Test Plan
This is the response headers for when the browser  requests for a default avatar. It now shows 304 when the etag header was sent 
![Screenshot from 2020-08-09 21-23-34](https://user-images.githubusercontent.com/15314237/89749885-e4f5ac80-da86-11ea-8bca-9fa111ea1eab.png)